### PR TITLE
Patch 1

### DIFF
--- a/Source/Core/ModExtensions/FactionRestrictions.cs
+++ b/Source/Core/ModExtensions/FactionRestrictions.cs
@@ -1,12 +1,13 @@
-﻿using Verse;
+﻿using System.Collections.Generic;
+using Verse;
 
 namespace GiddyUp
 {
     class FactionRestrictions : DefModExtension
     {
         //Can be used in xml patches to restrict animals per faction. 
-        public PawnKindDef[] allowedNonWildAnimals = new PawnKindDef[0];
-        public PawnKindDef[] allowedWildAnimals = new PawnKindDef[0];
+        public List<PawnKindDef> allowedNonWildAnimals = new List<PawnKindDef>();
+        public List<PawnKindDef> allowedWildAnimals = new List<PawnKindDef>();
         public int mountChance = -1;
         public int wildAnimalWeight = -1;
         public int nonWildAnimalWeight = -1;

--- a/Source/Core/MountUtility.cs
+++ b/Source/Core/MountUtility.cs
@@ -447,8 +447,8 @@ namespace GiddyUp
 				FactionRestrictions factionRules = parms.faction?.def?.GetModExtension<FactionRestrictions>();
 				if (factionRules != null)
 				{
-                    //Override working list
-                    wildAnimals = factionRules.allowedWildAnimals.ToArray();
+					//Override working list
+					wildAnimals = factionRules.allowedWildAnimals.ToArray();
 					var wildAnimalsReadonly = wildAnimals;
 					domesticAnimals = factionRules.allowedNonWildAnimals.ToArray();
 					localAnimals = map.Biome.AllWildAnimals.

--- a/Source/Core/MountUtility.cs
+++ b/Source/Core/MountUtility.cs
@@ -447,10 +447,10 @@ namespace GiddyUp
 				FactionRestrictions factionRules = parms.faction?.def?.GetModExtension<FactionRestrictions>();
 				if (factionRules != null)
 				{
-					//Override working list
-					wildAnimals = factionRules.allowedWildAnimals;
+                    //Override working list
+                    wildAnimals = factionRules.allowedWildAnimals.ToArray();
 					var wildAnimalsReadonly = wildAnimals;
-					domesticAnimals = factionRules.allowedNonWildAnimals;
+					domesticAnimals = factionRules.allowedNonWildAnimals.ToArray();
 					localAnimals = map.Biome.AllWildAnimals.
 						Where(x => wildAnimalsReadonly.Contains(x) && map.mapTemperature.SeasonAcceptableFor(x.race) && 
 						Settings.mountableCache.Contains(x.shortHash) && parms.points > x.combatPower * 2f).ToArray();


### PR DESCRIPTION
This fixes the startup issue when utilizing FactionRestrictions. 
To reproduce:
Use the simplified patch [here](https://gist.github.com/feeddanoob/64fa5a06ad077d2c370a769b4cfc98f3). The patch will set a mount restriction for any pirate faction.
You will get errors similar to [this](https://gist.github.com/HugsLibRecordKeeper/6f57f60acc2db3312c0788dfde826a7c#file-output_log-txt-L4339).

This only fixes the startup issues. I have noticed that using the patch file above, pirate factions can use other animals.
